### PR TITLE
chore: FastAPI 0.136.3 更新と SQLAlchemy / Pydantic 記述の最新化

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ FastAPI は容易に WebAPI が開発でき、少ないコードの記述で実�
 
 #### 使用ライブラリ
 - フレームワーク
-    - [FastAPI](https://fastapi.tiangolo.com/ja/)(Gunicorn含む)
+    - [FastAPI](https://fastapi.tiangolo.com/ja/) 0.136.3（`fastapi-debug-toolbar` 互換のため 0.137 未満に固定）
+    - 開発サーバーは `fastapi dev` を使用
 - O/Rマッパー
     - [SQLAlchemy](https://www.sqlalchemy.org/)
 - マイグレーションツール

--- a/app/database.py
+++ b/app/database.py
@@ -3,7 +3,7 @@
 from debug_toolbar.panels.sqlalchemy import SQLAlchemyPanel as BasePanel
 from fastapi import Request
 from sqlalchemy import create_engine
-from sqlalchemy.orm import declarative_base, scoped_session, sessionmaker
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 from app import const
 
@@ -14,15 +14,15 @@ engine = create_engine(
     echo=False,
 )
 
-SessionLocal = scoped_session(
-    sessionmaker(
-        autocommit=False,
-        autoflush=False,
-        bind=engine,
-    ),
+SessionLocal = sessionmaker(
+    autocommit=False,
+    autoflush=False,
+    bind=engine,
 )
 
-Base = declarative_base()
+
+class Base(DeclarativeBase):
+    pass
 
 
 class SQLAlchemyPanel(BasePanel):

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,9 +1,18 @@
+from collections.abc import Generator
+from typing import Annotated
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
 from .database import SessionLocal
 
 
-def get_db():
+def get_db() -> Generator[Session, None, None]:
     db = SessionLocal()
     try:
         yield db
     finally:
         db.close()
+
+
+DbSession = Annotated[Session, Depends(get_db)]

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 
 from fastapi import FastAPI
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.const import TodoItemStatusCode
 
@@ -44,6 +44,8 @@ class UpdateTodoItem(BaseModel):
 
 
 class ResponseTodoItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     todo_list_id: int
     title: str = Field(title="Todo Item Title", min_length=1, max_length=100)
@@ -70,6 +72,8 @@ class UpdateTodoList(BaseModel):
 
 class ResponseTodoList(BaseModel):
     """TODOリストのレスポンススキーマ."""
+
+    model_config = ConfigDict(from_attributes=True)
 
     id: int
     title: str = Field(title="Todo List Title", min_length=1, max_length=100)

--- a/app/models/item_model.py
+++ b/app/models/item_model.py
@@ -1,8 +1,13 @@
-from typing import ClassVar
+from datetime import datetime
+from typing import TYPE_CHECKING, ClassVar
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func, text
+from sqlalchemy import DateTime, ForeignKey, Integer, String, func, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.list_model import ListModel
 
 
 class ItemModel(Base):
@@ -12,11 +17,16 @@ class ItemModel(Base):
         "comment": "アイテムテーブル",
     }
 
-    id = Column("id", Integer, primary_key=True, autoincrement=True)
-    todo_list_id = Column("todo_list_id", Integer, ForeignKey("todo_lists.id"), nullable=False)
-    title = Column("title", String(50), nullable=False)
-    description = Column("description", String(200))
-    status_code = Column("status_code", Integer)
-    due_at = Column("due_at", DateTime)
-    created_at = Column("created_at", DateTime, server_default=func.now())
-    updated_at = Column("updated_at", DateTime, server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"))
+    id: Mapped[int] = mapped_column("id", Integer, primary_key=True, autoincrement=True)
+    todo_list_id: Mapped[int] = mapped_column("todo_list_id", Integer, ForeignKey("todo_lists.id"), nullable=False)
+    title: Mapped[str] = mapped_column("title", String(50), nullable=False)
+    description: Mapped[str | None] = mapped_column("description", String(200))
+    status_code: Mapped[int | None] = mapped_column("status_code", Integer)
+    due_at: Mapped[datetime | None] = mapped_column("due_at", DateTime)
+    created_at: Mapped[datetime] = mapped_column("created_at", DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
+        DateTime,
+        server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+    )
+    todo_list: Mapped["ListModel"] = relationship(back_populates="items")

--- a/app/models/list_model.py
+++ b/app/models/list_model.py
@@ -1,9 +1,13 @@
-from typing import ClassVar
+from datetime import datetime
+from typing import TYPE_CHECKING, ClassVar
 
-from sqlalchemy import Column, DateTime, Integer, String, func, text
-from sqlalchemy.orm import relationship
+from sqlalchemy import DateTime, Integer, String, func, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.item_model import ItemModel
 
 
 class ListModel(Base):
@@ -14,9 +18,13 @@ class ListModel(Base):
         "comment": "TODOリストテーブル",
     }
 
-    id = Column("id", Integer, primary_key=True, autoincrement=True)
-    title = Column("title", String(50), nullable=False)
-    description = Column("description", String(200))
-    created_at = Column("created_at", DateTime, server_default=func.now())
-    updated_at = Column("updated_at", DateTime, server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"))
-    items = relationship("ItemModel", backref="todo_lists")
+    id: Mapped[int] = mapped_column("id", Integer, primary_key=True, autoincrement=True)
+    title: Mapped[str] = mapped_column("title", String(50), nullable=False)
+    description: Mapped[str | None] = mapped_column("description", String(200))
+    created_at: Mapped[datetime] = mapped_column("created_at", DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
+        DateTime,
+        server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"),
+    )
+    items: Mapped[list["ItemModel"]] = relationship(back_populates="todo_list")

--- a/infra/docker/app/requirements/base.txt
+++ b/infra/docker/app/requirements/base.txt
@@ -1,5 +1,6 @@
 uvicorn==0.30.1
-fastapi==0.111.0
+fastapi[standard-no-fastapi-cloud-cli]==0.136.3
+fastapi-cli==0.0.28
 PyMySQL==1.1.1
 sqlalchemy==2.0.31
 alembic==1.13.2

--- a/infra/docker/app/requirements/dev.txt
+++ b/infra/docker/app/requirements/dev.txt
@@ -1,5 +1,6 @@
 -r base.txt
 fastapi-debug-toolbar==0.6.3
+httpx2>=2.0.0
 pytest==8.2.2
 pytest-cov==5.0.0
 pytest-env==1.1.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from sqlalchemy import inspect
+from sqlalchemy.orm import Session
 
 from app.database import SessionLocal, engine
 from app.models import item_model, list_model
@@ -16,7 +17,13 @@ def db_session():
         db.close()
 
 
-def _reset_records(db) -> None:
+def refresh_session(db: Session) -> None:
+    """API呼び出し後にテスト用DBセッションの状態をリセットする."""
+    db.rollback()
+    db.expire_all()
+
+
+def _reset_records(db: Session) -> None:
     """テーブルのレコードをリセット."""
     inspector = inspect(engine)
     table_names = inspector.get_table_names()

--- a/tests/test_station08.py
+++ b/tests/test_station08.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 from app.models import list_model
+from tests.conftest import refresh_session
 
 client = TestClient(app)
 
@@ -25,7 +26,7 @@ def test_put_todo_list(db_session) -> None:
     })
 
     # 実行結果の検証
-    db_session.reset()
+    refresh_session(db_session)
 
     assert response.status_code == status.HTTP_200_OK
 

--- a/tests/test_station09.py
+++ b/tests/test_station09.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 from app.models import list_model
+from tests.conftest import refresh_session
 
 client = TestClient(app)
 
@@ -20,7 +21,7 @@ def test_delete_todo_list(db_session) -> None:
     response = client.delete(f"/lists/{target_todo_list_id}")
 
     # 実行結果の検証
-    db_session.reset()
+    refresh_session(db_session)
 
     assert response.status_code == status.HTTP_200_OK
 

--- a/tests/test_station10.py
+++ b/tests/test_station10.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from app.const import TodoItemStatusCode
 from app.main import app
 from app.models import item_model, list_model
+from tests.conftest import refresh_session
 
 client = TestClient(app)
 
@@ -39,7 +40,7 @@ def test_get_todo_item(db_session) -> None:
     # 実行結果の検証開始
     # ******************
     # 検証に支障を来たす不要なトランザクション破棄のためDBセッションのリセット
-    db_session.reset()
+    refresh_session(db_session)
 
     # ステータスコードの確認
     assert response.status_code == status.HTTP_200_OK

--- a/tests/test_station11.py
+++ b/tests/test_station11.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from app.const import TodoItemStatusCode
 from app.main import app
 from app.models import item_model, list_model
+from tests.conftest import refresh_session
 
 client = TestClient(app)
 
@@ -33,7 +34,7 @@ def test_post_todo_item(db_session) -> None:
     # 実行結果の検証開始
     # ******************
     # 検証に支障を来たす不要なトランザクション破棄のためDBセッションのリセット
-    db_session.reset()
+    refresh_session(db_session)
 
     # ステータスコードの確認
     assert response.status_code == status.HTTP_200_OK

--- a/tests/test_station12.py
+++ b/tests/test_station12.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from app.const import TodoItemStatusCode
 from app.main import app
 from app.models import item_model, list_model
+from tests.conftest import refresh_session
 
 client = TestClient(app)
 
@@ -53,7 +54,7 @@ def test_put_todo_item(status_code: int, db_session) -> None:
     # 実行結果の検証開始
     # ******************
     # 検証に支障を来たす不要なトランザクション破棄のためDBセッションのリセット
-    db_session.reset()
+    refresh_session(db_session)
 
     # ステータスコードの確認
     assert response.status_code == status.HTTP_200_OK

--- a/tests/test_station13.py
+++ b/tests/test_station13.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 from app.models import item_model, list_model
+from tests.conftest import refresh_session
 
 client = TestClient(app)
 
@@ -39,7 +40,7 @@ def test_delete_todo_item(db_session) -> None:
     # 実行結果の検証開始
     # ******************
     # 検証に支障を来たす不要なトランザクション破棄のためDBセッションのリセット
-    db_session.reset()
+    refresh_session(db_session)
 
     # ステータスコードの確認
     assert response.status_code == status.HTTP_200_OK

--- a/tests/test_station16.py
+++ b/tests/test_station16.py
@@ -24,7 +24,7 @@ def test_post_todo_list_422_title_validation_error() -> None:
     })
 
     # 実行結果の検証
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_put_todo_list_404_list_not_found() -> None:

--- a/tests/test_station17.py
+++ b/tests/test_station17.py
@@ -110,7 +110,7 @@ def test_post_todo_item_422_validation_error(db_session) -> None:
     # 実行結果の検証開始
     # ******************
     # ステータスコードの確認
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 def test_put_todo_item_404_list_not_found(db_session) -> None:


### PR DESCRIPTION
## Summary

1年以上更新が止まっていたテンプレートリポジトリについて、FastAPI を 0.111.0 から 0.136.3 へ更新し、アプリコード・テストの記述を現行のベストプラクティスに合わせて整備しました。

- FastAPI **0.136.3** に固定（`fastapi-debug-toolbar` 0.6.3 が FastAPI 0.137+ で互換問題を起こすため）
- SQLAlchemy 2.0 推奨記述へ移行（`DeclarativeBase` / `Mapped` + `mapped_column` / `sessionmaker`）
- Pydantic v2 推奨記述へ移行（Response スキーマに `ConfigDict(from_attributes=True)`）
- 依存注入パターンの更新（`DbSession = Annotated[Session, Depends(get_db)]`）
- Starlette の deprecation 対応（`HTTP_422_UNPROCESSABLE_CONTENT`、`httpx2` 追加）
- お試し参照実装により **Station 02〜18 の全テスト合格**を確認（詳細は Test plan 参照）

## 変更内容

### 依存関係

| パッケージ | 変更 |
|-----------|------|
| FastAPI | 0.111.0 → **0.136.3**（`fastapi[standard-no-fastapi-cloud-cli]`） |
| fastapi-cli | 新規追加（0.0.28） |
| httpx2 | dev 依存に追加（TestClient の deprecation 解消） |

### アプリコード

- **`app/database.py`**: `declarative_base` / `scoped_session` を廃止し、`DeclarativeBase` + `sessionmaker` に変更
- **`app/models/`**: `Column` 定義を `Mapped` + `mapped_column` に変更、`relationship` を `back_populates` に整理
- **`app/dependencies.py`**: `get_db()` に型ヒントを追加、`DbSession` 型エイリアスを export
- **`app/main.py`**: Response スキーマに `ConfigDict(from_attributes=True)` を追加

#### `scoped_session` 廃止の 補足
- FastAPI の [SQL データベース チュートリアル](https://fastapi.tiangolo.com/ja/tutorial/sql-databases/) では、リクエストごとに 独立した Session を yield で渡す パターンが標準です。
- scoped_session は「スレッド／リクエストごとに同じセッションを自動で返す」仕組みで、Flask などと組み合わせる時代のパターン。FastAPI では Depends(get_db) がすでに「1リクエスト = 1セッション」を保証するため、二重のスコープ管理になる。

### テスト

- **`tests/conftest.py`**: `scoped_session.reset()` の代替として `refresh_session()` ヘルパーを追加
- **Station 08〜13**: `db_session.reset()` → `refresh_session(db_session)` に置換
- **Station 16/17**: `HTTP_422_UNPROCESSABLE_ENTITY` → `HTTP_422_UNPROCESSABLE_CONTENT`

### ドキュメント

- **`README.md`**: FastAPI 0.136.3 固定理由と `fastapi dev` 利用を追記

## お試し参照実装による動作確認

テンプレート starter コードのままでは Station 06 以降は未実装のため、**全 Station 相当の CRUD・リファクタリング・ページネーションを含む参照実装**をローカルで試し、テスト実行による動作確認を行いました。

## 教材テキスト側の修正
現在はアクセスできないので手元に残っている教材テキストから今回の変更に合わせて見直し必要な部分を、AIに整理してもらったものをご参考で添付しておきたいと思います。
[content_update_notes.md](https://github.com/user-attachments/files/29660033/content_update_notes.md)
